### PR TITLE
fix: add namespace prefix to cmov_int16 calls in Kyber poly.c

### DIFF
--- a/Modules/PQClean/crypto_kem/kyber1024/aarch64/poly.c
+++ b/Modules/PQClean/crypto_kem/kyber1024/aarch64/poly.c
@@ -189,7 +189,7 @@ void poly_frommsg(int16_t r[KYBER_N], const uint8_t msg[KYBER_INDCPA_MSGBYTES]) 
     for (i = 0; i < KYBER_N / 8; i++) {
         for (j = 0; j < 8; j++) {
             r->coeffs[8*i+j] = 0;
-            cmov_int16(r->coeffs+8*i+j, ((KYBER_Q+1)/2), (msg[i] >> j)&1);
+            PQCLEAN_KYBER1024_AARCH64_cmov_int16(r->coeffs+8*i+j, ((KYBER_Q+1)/2), (msg[i] >> j)&1);
         }
     }
 }

--- a/Modules/PQClean/crypto_kem/kyber1024/clean/poly.c
+++ b/Modules/PQClean/crypto_kem/kyber1024/clean/poly.c
@@ -133,7 +133,7 @@ void PQCLEAN_KYBER1024_CLEAN_poly_frommsg(poly *r, const uint8_t msg[KYBER_INDCP
     for (i = 0; i < KYBER_N / 8; i++) {
         for (j = 0; j < 8; j++) {
             r->coeffs[8*i+j] = 0;
-            cmov_int16(r->coeffs+8*i+j, ((KYBER_Q+1)/2), (msg[i] >> j)&1);
+            PQCLEAN_KYBER1024_CLEAN_cmov_int16(r->coeffs+8*i+j, ((KYBER_Q+1)/2), (msg[i] >> j)&1);
         }
     }
 }

--- a/Modules/PQClean/crypto_kem/kyber512/aarch64/poly.c
+++ b/Modules/PQClean/crypto_kem/kyber512/aarch64/poly.c
@@ -176,7 +176,7 @@ void poly_frommsg(int16_t r[KYBER_N], const uint8_t msg[KYBER_INDCPA_MSGBYTES]) 
     for (i = 0; i < KYBER_N / 8; i++) {
         for (j = 0; j < 8; j++) {
             r->coeffs[8*i+j] = 0;
-            cmov_int16(r->coeffs+8*i+j, ((KYBER_Q+1)/2), (msg[i] >> j)&1);
+            PQCLEAN_KYBER512_AARCH64_cmov_int16(r->coeffs+8*i+j, ((KYBER_Q+1)/2), (msg[i] >> j)&1);
         }
     }
 }

--- a/Modules/PQClean/crypto_kem/kyber512/clean/poly.c
+++ b/Modules/PQClean/crypto_kem/kyber512/clean/poly.c
@@ -120,7 +120,7 @@ void PQCLEAN_KYBER512_CLEAN_poly_frommsg(poly *r, const uint8_t msg[KYBER_INDCPA
     for (i = 0; i < KYBER_N / 8; i++) {
         for (j = 0; j < 8; j++) {
             r->coeffs[8*i+j] = 0;
-            cmov_int16(r->coeffs+8*i+j, ((KYBER_Q+1)/2), (msg[i] >> j)&1);
+            PQCLEAN_KYBER512_CLEAN_cmov_int16(r->coeffs+8*i+j, ((KYBER_Q+1)/2), (msg[i] >> j)&1);
         }
     }
 }

--- a/Modules/PQClean/crypto_kem/kyber768/aarch64/poly.c
+++ b/Modules/PQClean/crypto_kem/kyber768/aarch64/poly.c
@@ -176,7 +176,7 @@ void poly_frommsg(int16_t r[KYBER_N], const uint8_t msg[KYBER_INDCPA_MSGBYTES]) 
     for (i = 0; i < KYBER_N / 8; i++) {
         for (j = 0; j < 8; j++) {
             r->coeffs[8*i+j] = 0;
-            cmov_int16(r->coeffs+8*i+j, ((KYBER_Q+1)/2), (msg[i] >> j)&1);
+            PQCLEAN_KYBER768_AARCH64_cmov_int16(r->coeffs+8*i+j, ((KYBER_Q+1)/2), (msg[i] >> j)&1);
         }
     }
 }

--- a/Modules/PQClean/crypto_kem/kyber768/clean/poly.c
+++ b/Modules/PQClean/crypto_kem/kyber768/clean/poly.c
@@ -120,7 +120,7 @@ void PQCLEAN_KYBER768_CLEAN_poly_frommsg(poly *r, const uint8_t msg[KYBER_INDCPA
     for (i = 0; i < KYBER_N / 8; i++) {
         for (j = 0; j < 8; j++) {
             r->coeffs[8*i+j] = 0;
-            cmov_int16(r->coeffs+8*i+j, ((KYBER_Q+1)/2), (msg[i] >> j)&1);
+            PQCLEAN_KYBER768_CLEAN_cmov_int16(r->coeffs+8*i+j, ((KYBER_Q+1)/2), (msg[i] >> j)&1);
         }
     }
 }


### PR DESCRIPTION
## Summary

The commit b9067fe2 introduced `cmov_int16()` to fix the timing vulnerability (GHSA-hvh4-5qr6-3v7r) but called it without the PQClean namespace prefix, causing linker errors on Windows (and potentially other platforms).

## The Problem

```c
// Before (broken - unresolved symbol)
cmov_int16(r->coeffs+8*i+j, ((KYBER_Q+1)/2), (msg[i] >> j)&1);
```

## The Fix

```c
// After (correct - uses namespaced function)
PQCLEAN_KYBER768_CLEAN_cmov_int16(r->coeffs+8*i+j, ((KYBER_Q+1)/2), (msg[i] >> j)&1);
```

## Files Changed

- `crypto_kem/kyber512/clean/poly.c`
- `crypto_kem/kyber768/clean/poly.c`
- `crypto_kem/kyber1024/clean/poly.c`
- `crypto_kem/kyber512/aarch64/poly.c`
- `crypto_kem/kyber768/aarch64/poly.c`
- `crypto_kem/kyber1024/aarch64/poly.c`

## Testing

- Builds successfully on Windows with MSVC
- `python -m pqc.demo` passes
- Kyber768 keypair/encap/decap operations work correctly

## Related

- Fixes build issue introduced by timing vulnerability fix
- Allows GHSA-hvh4-5qr6-3v7r to be properly closed with a working release